### PR TITLE
Fix Patreon link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nissan Leaf TCU reverse engineering
 [![](https://img.shields.io/github/sponsors/developerfromjokela?label=Sponsor&logo=GitHub)](https://github.com/sponsors/developerfromjokela)
 [![BuyMeACoffee](https://raw.githubusercontent.com/pachadotdev/buymeacoffee-badges/main/bmc-donate-yellow.svg)](https://www.buymeacoffee.com/developerfromjokela)
-[![Patreon](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-patreon.vercel.app%2Fapi%3Fusername%3Ddeveloperfromjokela%26type%3Dpatrons)](https://patreom.com/developerfromjokela)
+[![Patreon](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-patreon.vercel.app%2Fapi%3Fusername%3Ddeveloperfromjokela%26type%3Dpatrons)](https://patreon.com/developerfromjokela)
 [![Liberapay patrons](https://img.shields.io/liberapay/patrons/developerfromjokela?style=plastic&logo=liberapay&label=liberapay&link=https%3A%2F%2Fliberapay.com%2Fdeveloperfromjokela%2F)](https://liberapay.com/developerfromjokela/)
 
 


### PR DESCRIPTION
A suspicious link (I suspect a typo) in the ReadMe is redirecting traffic to strange places... I double checked that the account exists on the actual Patreon system and suggest fixing the link.